### PR TITLE
Changes generated hostname for compute-go bundles

### DIFF
--- a/src/utils/compute-util.ts
+++ b/src/utils/compute-util.ts
@@ -1,5 +1,5 @@
 // to-do: compute-go doesn't seem to replace old bundles. Generate a unique
 //        hostname for each new build.
 export function newHostname(name: string, version: number): string {
-  return `${name.toLocaleLowerCase().replace(/[^a-z0-9]/, '') || 'untitled'}-${version}-local`
+  return `${name.toLocaleLowerCase().replace(/[^a-z0-9]/, '') || 'untitled'}-${version}`
 }

--- a/src/utils/compute-util.ts
+++ b/src/utils/compute-util.ts
@@ -1,5 +1,5 @@
 // to-do: compute-go doesn't seem to replace old bundles. Generate a unique
 //        hostname for each new build.
 export function newHostname(name: string, version: number): string {
-  return `${name.toLocaleLowerCase().replace(/[^a-z0-9]/, '') || 'untitled'}-${version}.local`
+  return `${name.toLocaleLowerCase().replace(/[^a-z0-9]/, '') || 'untitled'}-${version}-local`
 }


### PR DESCRIPTION
## 💸 TL;DR

When doing local development, gRPC calls to `[hostname].localhost:1337` can be processed by compute-go. However, this only works if the `hostname` is one DNS "part", so bundles named e.g. `untitled-1712273914361.local` break this.

Changing this to `untitled-1712273914361` makes this path possible again, and makes local testing possible without gRPC-web.

## 🧪 Testing Steps / Validation

Validated this in local development. This request doesn't require any metadata to succeed.

![image](https://github.com/reddit/play/assets/769353/6868edf5-55d4-45d9-b1e3-2d6835edfd32)

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
