### PR TITLE
Fix layout width calculations

### DIFF
--- a/src/elements/play-preview.ts
+++ b/src/elements/play-preview.ts
@@ -48,6 +48,8 @@ export class PlayPreview extends LitElement {
       border-radius: 16px;
       min-height: 320px;
       box-shadow: var(--shadow-xs);
+      /* Prevents the border from throwing off the context.dimensions calculation */
+      box-sizing: content-box;
 
       /* When the background is visible, the preview is loading. */
       background-color: var(--color-interactive-background);
@@ -66,21 +68,20 @@ export class PlayPreview extends LitElement {
       transition-timing-function: ease-out;
     }
 
-    /* We want the width to be precisely correct since Devvitors get dimension information from context! */
     :host([previewWidth='288']) .preview {
-      width: calc(288px + (var(--border-width) * 2));
+      width: 288px;
     }
     :host([previewWidth='343']) .preview {
-      width: calc(343px + (var(--border-width) * 2));
+      width: 343px;
     }
     :host([previewWidth='400']) .preview {
-      width: calc(400px + (var(--border-width) * 2));
+      width: 400px;
     }
     :host([previewWidth='512']) .preview {
-      width: calc(512px + (var(--border-width) * 2));
+      width: 512px;
     }
     :host([previewWidth='718']) .preview {
-      width: calc(718px + (var(--border-width) * 2));
+      width: 718px;
     }
   `
 

--- a/src/elements/play-preview.ts
+++ b/src/elements/play-preview.ts
@@ -66,20 +66,21 @@ export class PlayPreview extends LitElement {
       transition-timing-function: ease-out;
     }
 
+    /* We want the width to be precisely correct since Devvitors get dimension information from context! */
     :host([previewWidth='288']) .preview {
-      width: 288px;
+      width: calc(288px + (var(--border-width) * 2));
     }
     :host([previewWidth='343']) .preview {
-      width: 343px;
+      width: calc(343px + (var(--border-width) * 2));
     }
     :host([previewWidth='400']) .preview {
-      width: 400px;
+      width: calc(400px + (var(--border-width) * 2));
     }
     :host([previewWidth='512']) .preview {
-      width: 512px;
+      width: calc(512px + (var(--border-width) * 2));
     }
     :host([previewWidth='718']) .preview {
-      width: 718px;
+      width: calc(718px + (var(--border-width) * 2));
     }
   `
 


### PR DESCRIPTION
<!-- If this pull request closes an issue, please mention the issue number below -->
Closes # <!-- Issue # here -->

## 💸 TL;DR
<!-- What's the three sentence summary of purpose of the PR -->

The width was always two pixels off because the border is two pixels. This is a lot more noticable now that we have `context.dimensions`. Added a calc to make it right.

![CleanShot 2024-04-10 at 15 34 42@2x](https://github.com/reddit/play/assets/153219522/2ca24611-fee7-4f69-8193-be830f0f6677)


## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [x] Contributor License Agreement (CLA) completed if not a Reddit employee
