### PR TITLE
Adjusts bundler output to work with Node.

### DIFF
--- a/src/bundler/compiler.ts
+++ b/src/bundler/compiler.ts
@@ -21,10 +21,14 @@ export function compile(env: tsvfs.VirtualTypeScriptEnvironment): string {
   const src =
     env.languageService.getEmitOutput(appEntrypointFilename).outputFiles[0]
       ?.text ?? ''
-  // Adapt bundle CommonJS output to format expected by runtime-lite.
+  // Adapt bundle CommonJS output to format expected by our runtimes.
+  // This is a light hack that satisfies two different runtime needs:
+  // * runtime-lite needs `exports` to be defined and aliased to `module.exports` like so.
+  // * Node wraps the file in a function that provides `module` and `exports` already, so
+  //   needs them not to be overwritten.
   return src.replace(
     /^"use strict";/,
-    '"use strict"; module.exports = {}; const {exports} = module;'
+    '"use strict"; if (!module.exports) { module.exports = {}; var exports = module.exports; }\n'
   )
 }
 

--- a/src/bundler/compiler.ts
+++ b/src/bundler/compiler.ts
@@ -23,9 +23,15 @@ export function compile(env: tsvfs.VirtualTypeScriptEnvironment): string {
       ?.text ?? ''
   // Adapt bundle CommonJS output to format expected by our runtimes.
   // This is a light hack that satisfies two different runtime needs:
-  // * runtime-lite needs `exports` to be defined and aliased to `module.exports` like so.
-  // * Node wraps the file in a function that provides `module` and `exports` already, so
-  //   needs them not to be overwritten.
+  // 1. runtime-lite needs `exports` to be defined and aliased to `module.exports` like so.
+  // 2. Node wraps the bundle's code in this function:
+  //
+  //    (function(exports, require, module, __filename, __dirname) {
+  //      // [ bundle code here ]
+  //    });
+  //
+  //    We can't overwrite `module.exports` (the resulting bundle won't actually export what
+  //    it needs to), and we can't declare `exports` with const/let ("already been declared").
   return src.replace(
     /^"use strict";/,
     '"use strict"; if (!module.exports) { module.exports = {}; var exports = module.exports; }\n'


### PR DESCRIPTION
## 💸 TL;DR

Adjusts bundler output to also work with Node.

## 📜 Details

* In Node, `require` calls are wrapped in a function that provides `modules` and `exports`. Redefining them caused the app to not load.
* Deleting the `src.replace` line modified here fixed Node, but broke `runtime-lite`, which needs those definitions shimmed in.
* The resulting code is a compromise that works in both cases, at the cost of an ugly `var` in the generated code. Sorry about that.

## 🧪 Testing Steps / Validation
* Testing a simple Devvit with Play that registers a custom post until I got it to fully load and render the post!

