### PR TITLE
Fix editor overflow: replace deprecated clip with hidden

### DIFF
--- a/src/elements/play-pen/play-pen.ts
+++ b/src/elements/play-pen/play-pen.ts
@@ -108,7 +108,7 @@ export class PlayPen extends LitElement {
       column-gap: 16px;
       display: flex;
       flex-direction: row;
-      overflow: clip;
+      overflow: hidden;
       padding-right: 16px;
       padding-left: 16px;
       row-gap: 16px;


### PR DESCRIPTION
## 💸 TL;DR
- The code editor was pushing the height of the UI beyond the view height
- `overflow: clip` requires additional parameters to define the clip margin and has other implications for scrolling
  - See: https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#clip

## 📜 Details
[Design Doc](<!-- insert Google Doc link here if applicable -->)

[Jira](<!-- insert Jira link if applicable -->)

<!-- Add additional details required for the PR: breaking changes, screenshots, external dependency changes -->

## 🧪 Testing Steps / Validation
<!-- add details on how this PR has been tested, include reproductions and screenshots where applicable -->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
