### PR TITLE
Node v18 -> v22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Install Node.js
         uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
       - name: Install Dependencies
         run: npm ci --no-fund
       - name: Test Format

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "vitest": "1.6.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.18.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "vitest": "1.6.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "exports": {
     ".": {

--- a/tools/build.js
+++ b/tools/build.js
@@ -11,7 +11,7 @@ import esbuild from 'esbuild'
 import {JSDOM} from 'jsdom'
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import pkg from '../package.json' assert {type: 'json'}
+import pkg from '../package.json' with {type: 'json'}
 import {esbuildConfig} from './esbuild-config.js'
 import {readTSDs} from './tsd.js'
 


### PR DESCRIPTION
## 💸 TL;DR
We're trying to get all of the dev platform up to supporting Node v22, and that includes Play!

## 📜 Details
- Set the node engine to be v22 or greater.
- Change how JSON imports are worded.

## 🧪 Testing Steps / Validation
No functional changes.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] CI tests (if present) are passing
- [x] Adheres to code style for repo
- [ ] ~~Contributor License Agreement (CLA) completed if not a Reddit employee~~
