### PR TITLE
[DX-7170] Migrate @devvit/protos imports to paths

### DIFF
--- a/src/bundler/linker.ts
+++ b/src/bundler/linker.ts
@@ -1,4 +1,5 @@
-import type {LinkedBundle, SerializableServiceDefinition} from '@devvit/protos'
+import type {LinkedBundle} from '@devvit/protos/types/devvit/runtime/bundle.js'
+import type {SerializableServiceDefinition} from '@devvit/protos/types/devvit/runtime/serializable.js'
 import type {AssetMap} from '@devvit/shared-types/Assets.js'
 
 type LinkerAssetMaps = {

--- a/src/elements/play-pen/play-pen.ts
+++ b/src/elements/play-pen/play-pen.ts
@@ -1,4 +1,5 @@
-import type {Empty, LinkedBundle} from '@devvit/protos'
+import type {LinkedBundle} from '@devvit/protos/types/devvit/runtime/bundle.js'
+import {type Empty} from '@devvit/protos/types/google/protobuf/empty.js'
 import {throttle} from '@devvit/shared-types/throttle.js'
 import type {DevvitUIError} from '@devvit/ui-renderer/client/devvit-custom-post.js'
 import type {VirtualTypeScriptEnvironment} from '@typescript/vfs'
@@ -37,6 +38,14 @@ import type {ColorScheme} from '../../types/color-scheme.js'
 import type {Diagnostics} from '../../types/diagnostics.js'
 import {newHostname} from '../../utils/compute-util.js'
 import {cssReset} from '../../utils/css-reset.js'
+import {
+  type AssetsFilesystemChange,
+  type AssetsFilesystemType,
+  type AssetsState,
+  type AssetsVirtualFileChange,
+  emptyAssetsState,
+  PlayAssets
+} from '../play-assets/play-assets.js'
 import type {OpenLine} from '../play-console.js'
 import type {PlayEditor} from '../play-editor/play-editor.js'
 import type {PlayToast} from '../play-toast.js'
@@ -49,14 +58,6 @@ import '../play-pen-header.js'
 import '../play-preview-controls.js'
 import '../play-preview.js'
 import '../play-toast.js'
-import {
-  type AssetsFilesystemChange,
-  type AssetsFilesystemType,
-  type AssetsState,
-  type AssetsVirtualFileChange,
-  emptyAssetsState,
-  PlayAssets
-} from '../play-assets/play-assets.js'
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/elements/play-preview.ts
+++ b/src/elements/play-preview.ts
@@ -3,7 +3,9 @@ import * as sandboxedRuntimeScript from '@devvit/previews/dist/sandboxed-pen.wor
 // @ts-expect-error
 import * as unsandboxedRuntimeScript from '@devvit/previews/dist/unsandboxed-pen.worker.min.js'
 
-import type {Empty, LinkedBundle, Metadata} from '@devvit/protos'
+import {type Metadata} from '@devvit/protos/lib/Types.js'
+import type {LinkedBundle} from '@devvit/protos/types/devvit/runtime/bundle.js'
+import {type Empty} from '@devvit/protos/types/google/protobuf/empty.js'
 import {
   LitElement,
   css,

--- a/src/runtime/bundle-store.ts
+++ b/src/runtime/bundle-store.ts
@@ -1,8 +1,6 @@
-import {
-  BundleServiceDefinition,
-  type Empty,
-  type LinkedBundle
-} from '@devvit/protos'
+import type {LinkedBundle} from '@devvit/protos/types/devvit/runtime/bundle.js'
+import {BundleServiceDefinition} from '@devvit/protos/types/devvit/service/bundle_service.js'
+import {type Empty} from '@devvit/protos/types/google/protobuf/empty.js'
 import {createChannel, createClient} from 'nice-grpc-web'
 
 export type BundleStore = {

--- a/src/runtime/remote-app.ts
+++ b/src/runtime/remote-app.ts
@@ -1,4 +1,4 @@
-import { type Metadata } from '@devvit/protos/lib/Types.js'
+import {type Metadata} from '@devvit/protos/lib/Types.js'
 import {
   CustomPostDefinition,
   type RenderPostRequest,
@@ -13,8 +13,8 @@ import {
   type HandleUIEventRequest,
   type HandleUIEventResponse
 } from '@devvit/protos/types/devvit/ui/events/v1alpha/handle_ui.js'
-import { type Empty } from '@devvit/protos/types/google/protobuf/empty.js'
-import type { UIApp } from '@devvit/ui-renderer/client/remote-app.js'
+import {type Empty} from '@devvit/protos/types/google/protobuf/empty.js'
+import type {UIApp} from '@devvit/ui-renderer/client/remote-app.js'
 import {
   Metadata as NiceMeta,
   createChannel,

--- a/src/runtime/remote-app.ts
+++ b/src/runtime/remote-app.ts
@@ -1,16 +1,20 @@
+import { type Metadata } from '@devvit/protos/lib/Types.js'
 import {
   CustomPostDefinition,
-  UIEventHandlerDefinition,
-  type Empty,
-  type HandleUIEventRequest,
-  type HandleUIEventResponse,
-  type Metadata,
   type RenderPostRequest,
-  type RenderPostResponse,
+  type RenderPostResponse
+} from '@devvit/protos/types/devvit/reddit/custom_post/v1alpha/custom_post.js'
+import {
   type UIRequest,
   type UIResponse
-} from '@devvit/protos'
-import type {UIApp} from '@devvit/ui-renderer/client/remote-app.js'
+} from '@devvit/protos/types/devvit/ui/block_kit/v1beta/ui.js'
+import {
+  UIEventHandlerDefinition,
+  type HandleUIEventRequest,
+  type HandleUIEventResponse
+} from '@devvit/protos/types/devvit/ui/events/v1alpha/handle_ui.js'
+import { type Empty } from '@devvit/protos/types/google/protobuf/empty.js'
+import type { UIApp } from '@devvit/ui-renderer/client/remote-app.js'
 import {
   Metadata as NiceMeta,
   createChannel,


### PR DESCRIPTION
Stop using the @devvit/protos barrel for imports. This is intended only
for code executed within apps. If app code isn't using an export, we
want the ability to delete it from the barrel.