### PR TITLE
Adds LogStream to the "uses" list in the linker

### DIFF
--- a/src/bundler/linker.ts
+++ b/src/bundler/linker.ts
@@ -151,6 +151,14 @@ function uses(): (LinkedBundle & {products: unknown})[] {
               responseType: 'devvit.plugin.logger.LogResponse',
               requestStream: false,
               responseStream: false
+            },
+            {
+              fullName: '/devvit.plugin.logger.Logger/LogStream',
+              name: 'LogStream',
+              requestType: 'devvit.plugin.logger.LogMessage',
+              responseType: 'devvit.plugin.logger.LogResponse',
+              requestStream: true,
+              responseStream: false
             }
           ],
           name: 'Logger',


### PR DESCRIPTION
## 💸 TL;DR

LogStream was recently added to the Logger service for deterministic logging from the new Node runtime. Declare this in the `uses` block the linker has.

## 📜 Details

[Jira (internal)](https://reddit.atlassian.net/browse/DX-6806)

