### PR TITLE
Don't require more than Node 20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "vitest": "1.6.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.18.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "vitest": "1.6.0"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=20"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
https://github.com/reddit/play/commit/baa9c0d11477142a416edba82ade7ca573db657e

We were going to hard require Node 22, but decided against it, only requiring >= 20. But, we never updated Play to reflect that. Doh!